### PR TITLE
Add documentation on re-flashing the board

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,8 @@ an unsigned package.  E.g.:
 Installation
 ------------
 
-To install, simply use dpkg to install the resulting .deb package.
+After the resulting .deb package has been installed the firmware still needs to be flashed to the Senoko board.
+
+To prevent malicious alteration of the firmware during normal operation the physical "reflash" button on the Senoko must be held down during firmware updates.
+
+Running `update-senoko` at the command line will guide you through the flashing process, including obtaining root access as necessary.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+firmware-senoko (2.2-r2) unstable; urgency=medium
+
+  * Update documentation to include information on flashing the Senoko. 
+
+ -- Michael Fincham <michael.fincham@catalyst.net.nz>  Wed, 06 May 2015 16:04:54 +1200
+
 firmware-senoko (2.2-r1) unstable; urgency=medium
 
   * Improve low-battery support

--- a/debian/docs
+++ b/debian/docs
@@ -1,0 +1,1 @@
+README.md


### PR DESCRIPTION
Small change to ensure README.md is copied in to /usr/share/doc/firmware-senoko, and contains quick instructions on re-flashing the board.
