### PR TITLE
Check for root before running.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ After the resulting .deb package has been installed the firmware still needs to 
 
 To prevent malicious alteration of the firmware during normal operation the physical "reflash" button on the Senoko must be held down during firmware updates.
 
-Running `update-senoko` at the command line will guide you through the flashing process, including obtaining root access as necessary.
+Running `update-senoko` as root at the command line will guide you through the flashing process.

--- a/update-senoko
+++ b/update-senoko
@@ -48,12 +48,17 @@ then
 	exit 3
 fi
 
-echo "Enabling Senoko reset lines..."
-sudo chmod a+rw /dev/ttymxc3
-echo 149 | sudo tee /sys/class/gpio/export 2> /dev/null
-echo out | sudo tee /sys/class/gpio/gpio149/direction 2> /dev/null
+if [ "${UID}" != "0" ]; then
+	echo "Error: Need root privilege"
+	exit 4
+fi
 
-sudo chmod a+rw /sys/class/gpio/gpio149/value
+echo "Enabling Senoko reset lines..."
+chmod a+rw /dev/ttymxc3
+echo 149 | tee /sys/class/gpio/export 2> /dev/null
+echo out | tee /sys/class/gpio/gpio149/direction 2> /dev/null
+
+chmod a+rw /sys/class/gpio/gpio149/value
 echo 1 > /sys/class/gpio/gpio149/value
 
 while true


### PR DESCRIPTION
Do this up-front rather than attempting to escalate later in the
script. This fixes a bug where the script will fail if sudo is
not installed.
