### PR TITLE
postinst: fix whiptail parameters

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -5,14 +5,14 @@ if [ "$1" = configure ] ; then
 	# Senoko firmware version is stored in registers 0x01 and 0x02.
 	# Concatenate these together to produce a version number that we can
 	# use to determine if firmware needs to be updated.
-	fwver=$(($(/usr/sbin/i2cget -f -y 0 0x20 0x1) * 256 + $(/usr/sbin/i2cget -f -y 0 0x20 0x2)))
+	fwver=$(($(/usr/sbin/i2cget -f -y 0 0x20 0x1 || echo 0) * 256 + $(/usr/sbin/i2cget -f -y 0 0x20 0x2 || echo 0)))
 	if [ ${fwver} -lt 515 ]
 	then
-		if whiptail --yesno "Update Senoko Battery Board" "Senoko battery firmware needs updating.  Are you plugged in to AC power?" 10 60
+		if whiptail --title "Update Senoko Battery Board" --yesno "Senoko battery firmware needs updating.  Are you plugged in to AC power?" 10 60
 		then
 			update-senoko
 		else
-			whiptail --msgbox "Update Senoko Battery Board" "Older firmware can cause problems with I2C.  Until you update, your system clock and battery status may not function properly.\n\nPlease run 'update-senoko' when you are connected to AC." 10 70
+			whiptail --title "Update Senoko Battery Board" --msgbox "Older firmware can cause problems with I2C.  Until you update, your system clock and battery status may not function properly.\n\nPlease run 'update-senoko' when you are connected to AC." 10 70
 		fi
 	else
 		echo "Firmware already up to date"


### PR DESCRIPTION
This fixes whiptail parameters. There was an extra parameter which caused an error. Converted to use title instead.
Also, since we are in errexit mode, we should be careful that calls that can fail be catched, otherwise the whole apt process will fail and leave the system in a broken and potentially unbootable state. Updated i2cget calls to output sane values even if an error occurs when trying to access the i2c bus. This happened to me when trying to update on an older kernel. A warning message might be good here also to warn users to reboot into a recent kernel before performing the update.
